### PR TITLE
Updated the URL and changed to extract the council reference.

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -31,9 +31,9 @@ loop do
     matches_1 = possible_date_1.match(/\b([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
     matches_2 = possible_date_2.match(/\b([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
     parsed_date = ""
-    if (matches_1.length >= 1)
+    if (!matches_1.nil? and matches_1.length >= 1)
       parsed_date = Date.parse(matches_1[0]).to_s
-    elsif (matches_2.length >= 1)
+    elsif (!matches_2.nil? and matches_2.length >= 1)
       parsed_date = Date.parse(matches_2[0]).to_s
     end
     

--- a/scraper.rb
+++ b/scraper.rb
@@ -27,9 +27,9 @@ loop do
     # Extract all text from the second <b>...</b> element under the div which has class "truncated-description" (and trim the trailing ".").
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     puts "    Raw date text 1: " + possible_date_1
-    puts "    Raw date text 1: " + possible_date_2
-    matches_1 = possible_date_1.match(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
-    matches_2 = possible_date_2.match(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    puts "    Raw date text 2: " + possible_date_2
+    matches_1 = possible_date_1.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    matches_2 = possible_date_2.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)
       parsed_date = Date.parse(matches_1[0]).to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -28,8 +28,8 @@ loop do
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     puts "    Raw date text 1: " + possible_date_1
     puts "    Raw date text 1: " + possible_date_2
-    matches_1 = possible_date_1.match(/\b([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
-    matches_2 = possible_date_2.match(/\b([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    matches_1 = possible_date_1.match(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    matches_2 = possible_date_2.match(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)
       parsed_date = Date.parse(matches_1[0]).to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -15,15 +15,15 @@ loop do
     application_count += 1
     info_url = li.at('a')['href']
     details_page = agent.get(info_url)
-    council_reference = details_page.search('div.truncated-description p')[1].inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
+    council_reference = details_page.search('div.truncated-description p')[1].inner_text.gsub(/[\r\n]/, "").sub(/.*Serial Number:/, '').squeeze(' ').strip
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
-      'description' => li.at('div.truncated-description').inner_text.gsub("\r\n", "").sub(/.*Development Details:/, '').squeeze(' ').strip,
+      'description' => li.at('div.truncated-description').inner_text.gsub(/[\r\n]/, "").sub(/.*Development Details:/, '').squeeze(' ').strip,
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',
       'date_scraped' => Date.today.to_s,
-      'on_notice_to' => Date.parse(li.search('div.truncated-description b')[1].inner_text.gsub("\r\n", "").squeeze(' ').strip.gsub(/\.$/, '')).to_s
+      'on_notice_to' => Date.parse(li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')).to_s
     }
     puts "Saving page #{page_number} application #{application_count} record."
     puts "    council_reference: " + record['council_reference']

--- a/scraper.rb
+++ b/scraper.rb
@@ -9,7 +9,7 @@ loop do
   page_number += 1
   page = agent.get("#{url}#{page_number}")
 
-  puts "Parsing the results on page #{page_number}."
+  puts "Parsing the results on page #{page_number}: #{url}#{page_number}"
   application_count = 0
   page.search('li.shared-content-block').each do |li|
     application_count += 1
@@ -21,9 +21,9 @@ loop do
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',
       'date_scraped' => Date.today.to_s,
-      'on_notice_to' => li.at('div.truncated-description').inner_text
+      'on_notice_to' => li.at('div.truncated-description').inner_text.gsub("\r\n", "").squeeze(' ').strip
     }
-    puts "Saving record."
+    puts "Saving page #{page_number} application #{application_count} record."
     puts "  council_reference: " + record['council_reference']
     puts "            address: " + record['address']
     puts "        description: " + record['description']
@@ -37,3 +37,4 @@ loop do
   puts "Found #{application_count} application(s) on page #{page_number}."
   break if application_count == 0
 end
+puts "Complete."

--- a/scraper.rb
+++ b/scraper.rb
@@ -28,8 +28,8 @@ loop do
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     puts "    Raw date text 1: " + possible_date_1
     puts "    Raw date text 2: " + possible_date_2
-    matches_1 = possible_date_1.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
-    matches_2 = possible_date_2.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    matches_1 = possible_date_1.scan(/\b[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
+    matches_2 = possible_date_2.scan(/\b[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
     puts matches_1
     puts matches_2
     if (matches_1.nil?)

--- a/scraper.rb
+++ b/scraper.rb
@@ -34,9 +34,17 @@ loop do
     puts matches_2
     if (matches_1.nil?)
       puts "matches_1 is nil"
+    else
+      puts "found matches 1"
+      puts matches_1[0]
+      puts matches_1[0][0]
     end
     if (matches_1.nil?)
       puts "matches_2 is nil"
+    else
+      puts "found matches 2"
+      puts matches_2[0]
+      puts matches_2[0][0]
     end
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)

--- a/scraper.rb
+++ b/scraper.rb
@@ -19,20 +19,20 @@ loop do
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
-      'description' => li.at('div.truncated-description').inner_text.sub(/.*Development Details:/, '').gsub("\r\n", "").squeeze(' ').strip,
+      'description' => li.at('div.truncated-description').inner_text.gsub("\r\n", "").sub(/.*Development Details:/, '').squeeze(' ').strip,
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',
       'date_scraped' => Date.today.to_s,
-      'on_notice_to' => li.search('div.truncated-description b')[1].inner_text.gsub("\r\n", "").squeeze(' ').strip.gsub(/\.$/, '')
+      'on_notice_to' => Date.parse(li.search('div.truncated-description b')[1].inner_text.gsub("\r\n", "").squeeze(' ').strip.gsub(/\.$/, '')).to_s
     }
     puts "Saving page #{page_number} application #{application_count} record."
-    puts "  council_reference: " + record['council_reference']
-    puts "            address: " + record['address']
-    puts "        description: " + record['description']
-    puts "           info_url: " + record['info_url']
-    puts "        comment_url: " + record['comment_url']
-    puts "       date_scraped: " + record['date_scraped']
-    puts "       on_notice_to: " + record['on_notice_to']
+    puts "    council_reference: " + record['council_reference']
+    puts "              address: " + record['address']
+    puts "          description: " + record['description']
+    puts "             info_url: " + record['info_url']
+    puts "          comment_url: " + record['comment_url']
+    puts "         date_scraped: " + record['date_scraped']
+    puts "         on_notice_to: " + record['on_notice_to']
     ScraperWiki.save_sqlite(['council_reference'], record)
   end
   

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ loop do
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',
       'date_scraped' => Date.today.to_s,
-      'on_notice_to' => li.at('div.truncated-description > strong').inner_text.gsub("\r\n", "").squeeze(' ').strip
+      'on_notice_to' => li.search('div.truncated-description > p > b')[1].inner_text.gsub("\r\n", "").squeeze(' ').strip
     }
     puts "Saving page #{page_number} application #{application_count} record."
     puts "  council_reference: " + record['council_reference']

--- a/scraper.rb
+++ b/scraper.rb
@@ -21,7 +21,7 @@ loop do
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
-      # Extract all text after "Development Details:" under the div which as class "truncated-description".
+      # Extract all text after "Development Details:" under the div which has class "truncated-description".
       'description' => li.at('div.truncated-description').inner_text.gsub(/[\r\n]/, "").sub(/.*Development Details:/, '').squeeze(' ').strip,
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',

--- a/scraper.rb
+++ b/scraper.rb
@@ -28,8 +28,8 @@ loop do
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     puts "    Raw date text 1: " + possible_date_1
     puts "    Raw date text 2: " + possible_date_2
-    matches_1 = possible_date_1.scan(/\b[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
-    matches_2 = possible_date_2.scan(/\b[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
+    matches_1 = possible_date_1.scan(/\b[0-9][0-9]?\s+[A-Z][A-Z][A-Z][A-Z]?\s+[0-9][0-9][0-9][0-9]$/i)
+    matches_2 = possible_date_2.scan(/\b[0-9][0-9]?\s+[A-Z][A-Z][A-Z][A-Z]?\s+[0-9][0-9][0-9][0-9]$/i)
     puts matches_1
     puts matches_2
     if (matches_1.nil?)

--- a/scraper.rb
+++ b/scraper.rb
@@ -21,13 +21,10 @@ loop do
     council_reference = details_page.search('div.truncated-description p')[1].inner_text.gsub(/[\r\n]/, "").sub(/.*Serial Number:/, '').squeeze(' ').strip
     
     # Attempt to find a date.
-    puts "Parsing information for " + council_reference
     # Extract all text from the first <b>...</b> element under the div which has class "truncated-description" (and trim the trailing ".").
     possible_date_1 = li.search('div.truncated-description b')[0].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     # Extract all text from the second <b>...</b> element under the div which has class "truncated-description" (and trim the trailing ".").
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
-    puts "    Raw date text 1: " + possible_date_1
-    puts "    Raw date text 2: " + possible_date_2
     matches_1 = possible_date_1.scan(/\b[0-9][0-9]?\s+[A-Z][A-Z][A-Z][A-Z]?\s+[0-9][0-9][0-9][0-9]$/i)
     matches_2 = possible_date_2.scan(/\b[0-9][0-9]?\s+[A-Z][A-Z][A-Z][A-Z]?\s+[0-9][0-9][0-9][0-9]$/i)
     parsed_date = ""

--- a/scraper.rb
+++ b/scraper.rb
@@ -15,7 +15,7 @@ loop do
     application_count += 1
     info_url = li.at('a')['href']
     details_page = agent.get(info_url)
-    council_reference = details_page.at('div.truncated-description p')[1].inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
+    council_reference = details_page.search('div.truncated-description p')[1].inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,7 @@ page.search('li.shared-content-block').each do |i|
     'info_url' => info_url,
     'comment_url' => 'mailto:mail@vincent.wa.gov.au',
     'date_scraped' => Date.today.to_s,
-    'on_notice_to' => i.at('div.truncated-description > p > strong').next_sibling.inner_text
+    'on_notice_to' => i.at('div.truncated-description > p').inner_text
   }
   puts "Saving record " + record['council_reference'] + ", " + record['address']
   ScraperWiki.save_sqlite(['council_reference'], record)

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,14 +14,16 @@ loop do
   page.search('li.shared-content-block').each do |li|
     application_count += 1
     info_url = li.at('a')['href']
+    details_page = agent.get(info_url)
+    council_reference = details_page.at('div.truncated_description').inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
     record = {
-      'council_reference' => info_url.split('/')[-2..-1].join('/'),
+      'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
-      'description' => li.at('div.truncated-description').inner_text,
+      'description' => li.at('div.truncated-description').inner_text.sub(/.*Development Details:/, '').gsub("\r\n", "").squeeze(' ').strip,
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',
       'date_scraped' => Date.today.to_s,
-      'on_notice_to' => li.at('div.truncated-description').inner_text.gsub("\r\n", "").squeeze(' ').strip
+      'on_notice_to' => li.at('div.truncated-description > strong').inner_text.gsub("\r\n", "").squeeze(' ').strip
     }
     puts "Saving page #{page_number} application #{application_count} record."
     puts "  council_reference: " + record['council_reference']

--- a/scraper.rb
+++ b/scraper.rb
@@ -30,6 +30,8 @@ loop do
     puts "    Raw date text 2: " + possible_date_2
     matches_1 = possible_date_1.scan(/[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
     matches_2 = possible_date_2.scan(/[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
+    puts matches_1
+    puts matches_2
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)
       parsed_date = Date.parse(matches_1[0]).to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -30,25 +30,11 @@ loop do
     puts "    Raw date text 2: " + possible_date_2
     matches_1 = possible_date_1.scan(/\b[0-9][0-9]?\s+[A-Z][A-Z][A-Z][A-Z]?\s+[0-9][0-9][0-9][0-9]$/i)
     matches_2 = possible_date_2.scan(/\b[0-9][0-9]?\s+[A-Z][A-Z][A-Z][A-Z]?\s+[0-9][0-9][0-9][0-9]$/i)
-    puts matches_1
-    puts matches_2
-    if (matches_1.nil?)
-      puts "matches_1 is nil"
-    else
-      puts "found matches 1"
-      puts matches_1[0]
-    end
-    if (matches_2.nil?)
-      puts "matches_2 is nil"
-    else
-      puts "found matches 2"
-      puts matches_2[0]
-    end
     parsed_date = ""
-    if (!matches_1.nil? and matches_1.length >= 1)
-      parsed_date = Date.parse(matches_1[0][0]).to_s
-    elsif (!matches_2.nil? and matches_2.length >= 1)
-      parsed_date = Date.parse(matches_2[0][0]).to_s
+    if (matches_1.length >= 1)
+      parsed_date = Date.parse(matches_1[0]).to_s
+    elsif (matches_2.length >= 1)
+      parsed_date = Date.parse(matches_2[0]).to_s
     end
     
     record = {

--- a/scraper.rb
+++ b/scraper.rb
@@ -35,7 +35,8 @@ loop do
       parsed_date = Date.parse(matches_1[0]).to_s
     elsif (matches_2.length >= 1)
       parsed_date = Date.parse(matches_2[0]).to_s
-
+    end
+    
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,

--- a/scraper.rb
+++ b/scraper.rb
@@ -11,12 +11,12 @@ page.search('li.shared-content-block').each do |i|
   info_url = i.at('a')['href']
   record = {
     'council_reference' => info_url.split('/')[-2..-1].join('/'),
-    'address' => i.inner_text.gsub("\r\n", "").squeeze(' ').strip,
-    'description' => i.at('div.truncated-description').next_sibling.inner_text,
+    'address' => i.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
+    'description' => i.at('div.truncated-description').inner_text,
     'info_url' => info_url,
     'comment_url' => 'mailto:mail@vincent.wa.gov.au',
     'date_scraped' => Date.today.to_s,
-    'on_notice_to' => i.at('div.truncated-description > p').inner_text
+    'on_notice_to' => i.at('div.truncated-description').inner_text
   }
   puts "Saving record " + record['council_reference'] + ", " + record['address']
   ScraperWiki.save_sqlite(['council_reference'], record)

--- a/scraper.rb
+++ b/scraper.rb
@@ -28,8 +28,8 @@ loop do
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     puts "    Raw date text 1: " + possible_date_1
     puts "    Raw date text 2: " + possible_date_2
-    matches_1 = possible_date_1.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
-    matches_2 = possible_date_2.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    matches_1 = possible_date_1.scan(/[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
+    matches_2 = possible_date_2.scan(/[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)
       parsed_date = Date.parse(matches_1[0]).to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -37,14 +37,12 @@ loop do
     else
       puts "found matches 1"
       puts matches_1[0]
-      puts matches_1[0][0]
     end
-    if (matches_1.nil?)
+    if (matches_2.nil?)
       puts "matches_2 is nil"
     else
       puts "found matches 2"
       puts matches_2[0]
-      puts matches_2[0][0]
     end
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,15 +1,16 @@
 require 'scraperwiki'
 require 'mechanize'
 
-url = "https://imagine.vincent.wa.gov.au/planning-consultations?page="
+url = "https://imagine.vincent.wa.gov.au/planning-consultations"
 
 agent = Mechanize.new
 page_number = 0
 loop do
   page_number += 1
-  page = agent.get("#{url}#{page_number}")
+  page_url = "#{url}?page=#{page_number}"
+  page = agent.get(page_url)
 
-  puts "Parsing the results on page #{page_number}: #{url}#{page_number}"
+  puts "Parsing the results on page #{page_number}: #{page_url}"
   application_count = 0
   page.search('li.shared-content-block').each do |li|
     application_count += 1

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,7 +5,7 @@ url = "https://imagine.vincent.wa.gov.au/planning-consultations?page="
 
 agent = Mechanize.new
 page_number = 1
-page = agent.get("#{url}#{page_number})
+page = agent.get("#{url}#{page_number}")
 page.search('li.shared-content-block').each do |i|  
   puts "Parsing the results on page #{page_number}"
   info_url = i.at('a')['href']
@@ -20,5 +20,5 @@ page.search('li.shared-content-block').each do |i|
   }
   puts "Saving record " + record['council_reference'] + ", " + record['address']
   ScraperWiki.save_sqlite(['council_reference'], record)
-  page_number += 1
 end
+page_number += 1

--- a/scraper.rb
+++ b/scraper.rb
@@ -18,6 +18,8 @@ loop do
     details_page = agent.get(info_url)
     # Extract all text after "Serial Number:" from the second paragraph under the div which has class "truncated-description".
     council_reference = details_page.search('div.truncated-description p')[1].inner_text.gsub(/[\r\n]/, "").sub(/.*Serial Number:/, '').squeeze(' ').strip
+    puts "Parsing information for " + council_reference
+    puts "    Raw date text: " + li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,

--- a/scraper.rb
+++ b/scraper.rb
@@ -28,15 +28,15 @@ loop do
     possible_date_2 = li.search('div.truncated-description b')[1].inner_text.gsub(/[\r\n]/, "").squeeze(' ').strip.gsub(/\.$/, '')
     puts "    Raw date text 1: " + possible_date_1
     puts "    Raw date text 2: " + possible_date_2
-    matches_1 = possible_date_1.scan(/[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
-    matches_2 = possible_date_2.scan(/[0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9]$/i)
+    matches_1 = possible_date_1.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
+    matches_2 = possible_date_2.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
     puts matches_1
     puts matches_2
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)
-      parsed_date = Date.parse(matches_1[0]).to_s
+      parsed_date = Date.parse(matches_1[0][0]).to_s
     elsif (!matches_2.nil? and matches_2.length >= 1)
-      parsed_date = Date.parse(matches_2[0]).to_s
+      parsed_date = Date.parse(matches_2[0][0]).to_s
     end
     
     record = {

--- a/scraper.rb
+++ b/scraper.rb
@@ -32,6 +32,12 @@ loop do
     matches_2 = possible_date_2.scan(/([0-9][0-9]?\w+[A-Z][A-Z][A-Z][A-Z]?\w+[0-9][0-9][0-9][0-9])$/i)
     puts matches_1
     puts matches_2
+    if (matches_1.nil?)
+      puts "matches_1 is nil"
+    end
+    if (matches_1.nil?)
+      puts "matches_2 is nil"
+    end
     parsed_date = ""
     if (!matches_1.nil? and matches_1.length >= 1)
       parsed_date = Date.parse(matches_1[0][0]).to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -4,21 +4,36 @@ require 'mechanize'
 url = "https://imagine.vincent.wa.gov.au/planning-consultations?page="
 
 agent = Mechanize.new
-page_number = 1
-page = agent.get("#{url}#{page_number}")
-page.search('li.shared-content-block').each do |i|  
-  puts "Parsing the results on page #{page_number}"
-  info_url = i.at('a')['href']
-  record = {
-    'council_reference' => info_url.split('/')[-2..-1].join('/'),
-    'address' => i.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
-    'description' => i.at('div.truncated-description').inner_text,
-    'info_url' => info_url,
-    'comment_url' => 'mailto:mail@vincent.wa.gov.au',
-    'date_scraped' => Date.today.to_s,
-    'on_notice_to' => i.at('div.truncated-description').inner_text
-  }
-  puts "Saving record " + record['council_reference'] + ", " + record['address']
-  ScraperWiki.save_sqlite(['council_reference'], record)
+page_number = 0
+loop do
+  page_number += 1
+  page = agent.get("#{url}#{page_number}")
+
+  puts "Parsing the results on page #{page_number}."
+  application_count = 0
+  page.search('li.shared-content-block').each do |li|
+    application_count += 1
+    info_url = li.at('a')['href']
+    record = {
+      'council_reference' => info_url.split('/')[-2..-1].join('/'),
+      'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
+      'description' => li.at('div.truncated-description').inner_text,
+      'info_url' => info_url,
+      'comment_url' => 'mailto:mail@vincent.wa.gov.au',
+      'date_scraped' => Date.today.to_s,
+      'on_notice_to' => li.at('div.truncated-description').inner_text
+    }
+    puts "Saving record."
+    puts "  council_reference: " + record['council_reference']
+    puts "            address: " + record['address']
+    puts "        description: " + record['description']
+    puts "           info_url: " + record['info_url']
+    puts "        comment_url: " + record['comment_url']
+    puts "       date_scraped: " + record['date_scraped']
+    puts "       on_notice_to: " + record['on_notice_to']
+    ScraperWiki.save_sqlite(['council_reference'], record)
+  end
+  
+  puts "Found #{application_count} application(s) on page #{page_number}."
+  break if application_count == 0
 end
-page_number += 1

--- a/scraper.rb
+++ b/scraper.rb
@@ -15,7 +15,7 @@ loop do
     application_count += 1
     info_url = li.at('a')['href']
     details_page = agent.get(info_url)
-    council_reference = details_page.at('div.truncated_description').inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
+    council_reference = details_page.at('div.truncated-description').inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,

--- a/scraper.rb
+++ b/scraper.rb
@@ -15,7 +15,7 @@ loop do
     application_count += 1
     info_url = li.at('a')['href']
     details_page = agent.get(info_url)
-    council_reference = details_page.at('div.truncated-description').inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
+    council_reference = details_page.at('div.truncated-description p')[1].inner_text.sub(/.*Serial Number:/, '').gsub("\r\n", "").squeeze(' ').strip
     record = {
       'council_reference' => council_reference,
       'address' => li.at('a').inner_text.gsub("\r\n", "").squeeze(' ').strip,
@@ -23,7 +23,7 @@ loop do
       'info_url' => info_url,
       'comment_url' => 'mailto:mail@vincent.wa.gov.au',
       'date_scraped' => Date.today.to_s,
-      'on_notice_to' => li.search('div.truncated-description > p > b')[1].inner_text.gsub("\r\n", "").squeeze(' ').strip
+      'on_notice_to' => li.search('div.truncated-description b')[1].inner_text.gsub("\r\n", "").squeeze(' ').strip.gsub(/\.$/, '')
     }
     puts "Saving page #{page_number} application #{application_count} record."
     puts "  council_reference: " + record['council_reference']

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,10 +16,6 @@ page.search('.listitemrow').each do |i|
     'date_scraped' => Date.today.to_s,
     'on_notice_to' => i.at('.listitemtext > b').next_sibling.inner_text.split('/').reverse.join('-')
   }
-  if (ScraperWiki.select("* from data where `council_reference`='#{record['council_reference']}'").empty? rescue true)
-    ScraperWiki.save_sqlite(['council_reference'], record)
-  else
-    puts "Skipping already saved record " + record['council_reference']
-  end
+  puts "Saving record " + record['council_reference'] + ", " + record['address']
+  ScraperWiki.save_sqlite(['council_reference'], record)
 end
-


### PR DESCRIPTION
The web site now includes the council reference (on the details page) so updated the scraper to extract this information.  This fixes issue #1.

The scraper is: https://morph.io/planningalerts-scrapers/vincent.